### PR TITLE
Fixed collection creation bug

### DIFF
--- a/backend/app.log
+++ b/backend/app.log
@@ -32011,3 +32011,507 @@ WHERE books.title = $1::VARCHAR AND books.author_id = $2::INTEGER
             
 2025-11-15 17:48:01,889 - INFO - [cached since 105.3s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
 2025-11-15 17:48:02,041 - INFO - ROLLBACK
+2025-11-15 21:10:40,370 - INFO - select pg_catalog.version()
+2025-11-15 21:10:40,370 - INFO - [raw sql] ()
+2025-11-15 21:10:40,475 - INFO - select current_schema()
+2025-11-15 21:10:40,475 - INFO - [raw sql] ()
+2025-11-15 21:10:40,567 - INFO - show standard_conforming_strings
+2025-11-15 21:10:40,567 - INFO - [raw sql] ()
+2025-11-15 21:10:40,630 - INFO - BEGIN (implicit)
+2025-11-15 21:10:40,648 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:10:40,648 - INFO - [generated in 0.00105s] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:10:40,732 - INFO - ROLLBACK
+2025-11-15 21:10:41,209 - INFO - BEGIN (implicit)
+2025-11-15 21:10:41,209 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:10:41,209 - INFO - [generated in 0.00075s] (5,)
+2025-11-15 21:10:41,292 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:10:41,292 - INFO - [generated in 0.00128s] (5,)
+2025-11-15 21:10:41,356 - INFO - ROLLBACK
+2025-11-15 21:10:41,427 - INFO - BEGIN (implicit)
+2025-11-15 21:10:41,429 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:10:41,429 - INFO - [cached since 0.2174s ago] (2,)
+2025-11-15 21:10:41,504 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:10:41,504 - INFO - [cached since 0.2021s ago] (2,)
+2025-11-15 21:10:41,555 - INFO - ROLLBACK
+2025-11-15 21:10:41,622 - INFO - BEGIN (implicit)
+2025-11-15 21:10:41,622 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:10:41,623 - INFO - [cached since 0.4103s ago] (1,)
+2025-11-15 21:10:41,672 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:10:41,673 - INFO - [cached since 0.3693s ago] (1,)
+2025-11-15 21:10:41,695 - INFO - ROLLBACK
+2025-11-15 21:18:09,419 - INFO - BEGIN (implicit)
+2025-11-15 21:18:09,419 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:18:09,419 - INFO - [cached since 448.8s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:19:03,107 - INFO - BEGIN (implicit)
+2025-11-15 21:19:03,107 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:19:03,107 - INFO - [cached since 502.5s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:19:03,210 - INFO - ROLLBACK
+2025-11-15 21:19:03,605 - INFO - BEGIN (implicit)
+2025-11-15 21:19:03,605 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:19:03,605 - INFO - [cached since 502.4s ago] (5,)
+2025-11-15 21:19:03,681 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:19:03,681 - INFO - [cached since 502.4s ago] (5,)
+2025-11-15 21:19:03,748 - INFO - ROLLBACK
+2025-11-15 21:19:03,836 - INFO - BEGIN (implicit)
+2025-11-15 21:19:03,836 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:19:03,836 - INFO - [cached since 502.6s ago] (2,)
+2025-11-15 21:19:03,907 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:19:03,907 - INFO - [cached since 502.6s ago] (2,)
+2025-11-15 21:19:03,957 - INFO - ROLLBACK
+2025-11-15 21:19:04,041 - INFO - BEGIN (implicit)
+2025-11-15 21:19:04,041 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:19:04,044 - INFO - [cached since 502.8s ago] (1,)
+2025-11-15 21:19:04,092 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:19:04,092 - INFO - [cached since 502.8s ago] (1,)
+2025-11-15 21:19:04,118 - INFO - ROLLBACK
+2025-11-15 21:25:41,793 - INFO - select pg_catalog.version()
+2025-11-15 21:25:41,793 - INFO - [raw sql] ()
+2025-11-15 21:25:41,882 - INFO - select current_schema()
+2025-11-15 21:25:41,882 - INFO - [raw sql] ()
+2025-11-15 21:25:41,972 - INFO - show standard_conforming_strings
+2025-11-15 21:25:41,974 - INFO - [raw sql] ()
+2025-11-15 21:25:42,041 - INFO - BEGIN (implicit)
+2025-11-15 21:25:42,052 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:25:42,052 - INFO - [generated in 0.00119s] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:25:42,125 - INFO - ROLLBACK
+2025-11-15 21:25:42,505 - INFO - BEGIN (implicit)
+2025-11-15 21:25:42,505 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:25:42,505 - INFO - [generated in 0.00075s] (5,)
+2025-11-15 21:25:42,607 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:25:42,607 - INFO - [generated in 0.00134s] (5,)
+2025-11-15 21:25:42,669 - INFO - ROLLBACK
+2025-11-15 21:25:42,735 - INFO - BEGIN (implicit)
+2025-11-15 21:25:42,735 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:25:42,735 - INFO - [cached since 0.2287s ago] (2,)
+2025-11-15 21:25:42,820 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:25:42,820 - INFO - [cached since 0.2097s ago] (2,)
+2025-11-15 21:25:42,885 - INFO - ROLLBACK
+2025-11-15 21:25:42,951 - INFO - BEGIN (implicit)
+2025-11-15 21:25:42,951 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:25:42,951 - INFO - [cached since 0.4357s ago] (1,)
+2025-11-15 21:25:42,985 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:25:42,985 - INFO - [cached since 0.386s ago] (1,)
+2025-11-15 21:25:43,024 - INFO - ROLLBACK
+2025-11-15 21:43:58,445 - INFO - select pg_catalog.version()
+2025-11-15 21:43:58,446 - INFO - [raw sql] ()
+2025-11-15 21:43:58,524 - INFO - select current_schema()
+2025-11-15 21:43:58,524 - INFO - [raw sql] ()
+2025-11-15 21:43:58,619 - INFO - show standard_conforming_strings
+2025-11-15 21:43:58,621 - INFO - [raw sql] ()
+2025-11-15 21:43:58,684 - INFO - BEGIN (implicit)
+2025-11-15 21:43:58,684 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:43:58,692 - INFO - [generated in 0.00094s] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:43:58,757 - INFO - ROLLBACK
+2025-11-15 21:43:59,126 - INFO - BEGIN (implicit)
+2025-11-15 21:43:59,126 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:43:59,126 - INFO - [generated in 0.00103s] (5,)
+2025-11-15 21:43:59,217 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:43:59,217 - INFO - [generated in 0.00168s] (5,)
+2025-11-15 21:43:59,267 - INFO - ROLLBACK
+2025-11-15 21:43:59,340 - INFO - BEGIN (implicit)
+2025-11-15 21:43:59,340 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:43:59,340 - INFO - [cached since 0.2116s ago] (2,)
+2025-11-15 21:43:59,413 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:43:59,413 - INFO - [cached since 0.1972s ago] (2,)
+2025-11-15 21:43:59,461 - INFO - ROLLBACK
+2025-11-15 21:43:59,530 - INFO - BEGIN (implicit)
+2025-11-15 21:43:59,535 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:43:59,535 - INFO - [cached since 0.4043s ago] (1,)
+2025-11-15 21:43:59,583 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:43:59,583 - INFO - [cached since 0.3665s ago] (1,)
+2025-11-15 21:43:59,602 - INFO - ROLLBACK
+2025-11-15 21:44:05,844 - INFO - BEGIN (implicit)
+2025-11-15 21:44:05,848 - INFO - SELECT collections.collection_id 
+FROM collections 
+WHERE collections.user_id = $1::UUID AND lower(collections.name) = $2::VARCHAR
+2025-11-15 21:44:05,848 - INFO - [generated in 0.00045s] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00', 'python')
+2025-11-15 21:44:05,917 - INFO - SELECT collections.collection_id 
+FROM collections 
+WHERE collections.user_id = $1::UUID AND lower(collections.name) = $2::VARCHAR
+2025-11-15 21:44:05,919 - INFO - [cached since 0.07251s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00', 'python')
+2025-11-15 21:44:05,945 - INFO - INSERT INTO collections (user_id, name, description, icon_id, created_at) VALUES ($1::UUID, $2::VARCHAR, $3::VARCHAR, $4::INTEGER, $5::TIMESTAMP WITH TIME ZONE) RETURNING collections.collection_id
+2025-11-15 21:44:05,945 - INFO - [generated in 0.00105s] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00', 'Python', None, 19, datetime.datetime(2025, 11, 16, 2, 44, 5, 931659, tzinfo=datetime.timezone.utc))
+2025-11-15 21:44:05,994 - INFO - COMMIT
+2025-11-15 21:44:20,822 - INFO - BEGIN (implicit)
+2025-11-15 21:44:20,822 - INFO - SELECT collections.collection_id 
+FROM collections 
+WHERE collections.user_id = $1::UUID AND lower(collections.name) = $2::VARCHAR
+2025-11-15 21:44:20,822 - INFO - [cached since 14.99s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00', 'python')
+2025-11-15 21:44:20,898 - INFO - ROLLBACK
+2025-11-15 21:44:28,381 - INFO - BEGIN (implicit)
+2025-11-15 21:44:28,381 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:44:28,381 - INFO - [cached since 29.69s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:44:28,429 - INFO - ROLLBACK
+2025-11-15 21:44:28,497 - INFO - BEGIN (implicit)
+2025-11-15 21:44:28,497 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:28,497 - INFO - [cached since 29.37s ago] (7,)
+2025-11-15 21:44:28,546 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:28,548 - INFO - [cached since 29.33s ago] (7,)
+2025-11-15 21:44:28,563 - INFO - ROLLBACK
+2025-11-15 21:44:28,647 - INFO - BEGIN (implicit)
+2025-11-15 21:44:28,650 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:28,650 - INFO - [cached since 29.52s ago] (5,)
+2025-11-15 21:44:28,696 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:28,697 - INFO - [cached since 29.48s ago] (5,)
+2025-11-15 21:44:28,713 - INFO - ROLLBACK
+2025-11-15 21:44:28,780 - INFO - BEGIN (implicit)
+2025-11-15 21:44:28,784 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:28,784 - INFO - [cached since 29.65s ago] (2,)
+2025-11-15 21:44:28,831 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:28,832 - INFO - [cached since 29.62s ago] (2,)
+2025-11-15 21:44:28,856 - INFO - ROLLBACK
+2025-11-15 21:44:28,928 - INFO - BEGIN (implicit)
+2025-11-15 21:44:28,929 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:28,929 - INFO - [cached since 29.8s ago] (1,)
+2025-11-15 21:44:28,979 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:28,979 - INFO - [cached since 29.76s ago] (1,)
+2025-11-15 21:44:29,000 - INFO - ROLLBACK
+2025-11-15 21:44:31,959 - INFO - BEGIN (implicit)
+2025-11-15 21:44:31,959 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:31,961 - INFO - [cached since 32.83s ago] (7,)
+2025-11-15 21:44:31,998 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:31,998 - INFO - [cached since 32.79s ago] (7,)
+2025-11-15 21:44:32,026 - INFO - ROLLBACK
+2025-11-15 21:44:44,776 - INFO - BEGIN (implicit)
+2025-11-15 21:44:44,776 - INFO - SELECT collections.collection_id 
+FROM collections 
+WHERE collections.user_id = $1::UUID AND lower(collections.name) = $2::VARCHAR
+2025-11-15 21:44:44,776 - INFO - [cached since 38.93s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00', 'c++')
+2025-11-15 21:44:44,821 - INFO - SELECT collections.collection_id 
+FROM collections 
+WHERE collections.user_id = $1::UUID AND lower(collections.name) = $2::VARCHAR
+2025-11-15 21:44:44,821 - INFO - [cached since 38.98s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00', 'c++')
+2025-11-15 21:44:44,849 - INFO - INSERT INTO collections (user_id, name, description, icon_id, created_at) VALUES ($1::UUID, $2::VARCHAR, $3::VARCHAR, $4::INTEGER, $5::TIMESTAMP WITH TIME ZONE) RETURNING collections.collection_id
+2025-11-15 21:44:44,849 - INFO - [cached since 38.9s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00', 'C++', None, 17, datetime.datetime(2025, 11, 16, 2, 44, 44, 847855, tzinfo=datetime.timezone.utc))
+2025-11-15 21:44:44,875 - INFO - COMMIT
+2025-11-15 21:44:50,743 - INFO - BEGIN (implicit)
+2025-11-15 21:44:50,743 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:44:50,743 - INFO - [cached since 52.06s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:44:50,815 - INFO - ROLLBACK
+2025-11-15 21:44:50,881 - INFO - BEGIN (implicit)
+2025-11-15 21:44:50,887 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:50,887 - INFO - [cached since 51.76s ago] (8,)
+2025-11-15 21:44:50,930 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:50,930 - INFO - [cached since 51.71s ago] (8,)
+2025-11-15 21:44:50,950 - INFO - ROLLBACK
+2025-11-15 21:44:51,031 - INFO - BEGIN (implicit)
+2025-11-15 21:44:51,031 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:51,031 - INFO - [cached since 51.9s ago] (7,)
+2025-11-15 21:44:51,066 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:51,076 - INFO - [cached since 51.86s ago] (7,)
+2025-11-15 21:44:51,099 - INFO - ROLLBACK
+2025-11-15 21:44:51,183 - INFO - BEGIN (implicit)
+2025-11-15 21:44:51,183 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:51,183 - INFO - [cached since 52.06s ago] (5,)
+2025-11-15 21:44:51,229 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:51,231 - INFO - [cached since 52.01s ago] (5,)
+2025-11-15 21:44:51,253 - INFO - ROLLBACK
+2025-11-15 21:44:51,317 - INFO - BEGIN (implicit)
+2025-11-15 21:44:51,317 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:51,326 - INFO - [cached since 52.19s ago] (2,)
+2025-11-15 21:44:51,367 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:51,367 - INFO - [cached since 52.15s ago] (2,)
+2025-11-15 21:44:51,396 - INFO - ROLLBACK
+2025-11-15 21:44:51,463 - INFO - BEGIN (implicit)
+2025-11-15 21:44:51,463 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:51,463 - INFO - [cached since 52.33s ago] (1,)
+2025-11-15 21:44:51,512 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:51,512 - INFO - [cached since 52.29s ago] (1,)
+2025-11-15 21:44:51,533 - INFO - ROLLBACK
+2025-11-15 21:44:55,368 - INFO - BEGIN (implicit)
+2025-11-15 21:44:55,368 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:44:55,368 - INFO - [cached since 56.68s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:44:55,407 - INFO - ROLLBACK
+2025-11-15 21:44:55,473 - INFO - BEGIN (implicit)
+2025-11-15 21:44:55,473 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:55,473 - INFO - [cached since 56.35s ago] (8,)
+2025-11-15 21:44:55,513 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:55,513 - INFO - [cached since 56.31s ago] (8,)
+2025-11-15 21:44:55,547 - INFO - ROLLBACK
+2025-11-15 21:44:58,645 - INFO - BEGIN (implicit)
+2025-11-15 21:44:58,645 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:44:58,645 - INFO - [cached since 59.51s ago] (7,)
+2025-11-15 21:44:58,689 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:44:58,689 - INFO - [cached since 59.47s ago] (7,)
+2025-11-15 21:44:58,714 - INFO - ROLLBACK
+2025-11-15 21:45:01,158 - INFO - BEGIN (implicit)
+2025-11-15 21:45:01,158 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:45:01,158 - INFO - [cached since 62.03s ago] (8,)
+2025-11-15 21:45:01,198 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:45:01,202 - INFO - [cached since 61.98s ago] (8,)
+2025-11-15 21:45:01,221 - INFO - ROLLBACK
+2025-11-15 21:45:07,617 - INFO - BEGIN (implicit)
+2025-11-15 21:45:07,617 - INFO - SELECT collections.collection_id, collections.user_id, collections.name, collections.description, collections.icon_id, collections.created_at 
+FROM collections 
+WHERE collections.user_id = $1::UUID ORDER BY collections.created_at DESC
+2025-11-15 21:45:07,617 - INFO - [cached since 68.93s ago] ('a37aaf7b-3d0a-4b7a-aab0-600e9b09ce00',)
+2025-11-15 21:45:07,667 - INFO - ROLLBACK
+2025-11-15 21:45:07,754 - INFO - BEGIN (implicit)
+2025-11-15 21:45:07,754 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:45:07,754 - INFO - [cached since 68.62s ago] (8,)
+2025-11-15 21:45:07,800 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:45:07,800 - INFO - [cached since 68.58s ago] (8,)
+2025-11-15 21:45:07,820 - INFO - ROLLBACK
+2025-11-15 21:45:07,917 - INFO - BEGIN (implicit)
+2025-11-15 21:45:07,917 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:45:07,917 - INFO - [cached since 68.79s ago] (7,)
+2025-11-15 21:45:07,964 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:45:07,964 - INFO - [cached since 68.75s ago] (7,)
+2025-11-15 21:45:07,997 - INFO - ROLLBACK
+2025-11-15 21:45:08,082 - INFO - BEGIN (implicit)
+2025-11-15 21:45:08,082 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:45:08,082 - INFO - [cached since 68.95s ago] (5,)
+2025-11-15 21:45:08,132 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:45:08,133 - INFO - [cached since 68.92s ago] (5,)
+2025-11-15 21:45:08,155 - INFO - ROLLBACK
+2025-11-15 21:45:08,237 - INFO - BEGIN (implicit)
+2025-11-15 21:45:08,245 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:45:08,247 - INFO - [cached since 69.12s ago] (2,)
+2025-11-15 21:45:08,287 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:45:08,287 - INFO - [cached since 69.07s ago] (2,)
+2025-11-15 21:45:08,311 - INFO - ROLLBACK
+2025-11-15 21:45:08,400 - INFO - BEGIN (implicit)
+2025-11-15 21:45:08,400 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:45:08,400 - INFO - [cached since 69.27s ago] (1,)
+2025-11-15 21:45:08,434 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:45:08,445 - INFO - [cached since 69.23s ago] (1,)
+2025-11-15 21:45:08,466 - INFO - ROLLBACK
+2025-11-15 21:45:12,708 - INFO - BEGIN (implicit)
+2025-11-15 21:45:12,708 - INFO - SELECT 1 FROM collections WHERE collection_id = $1
+2025-11-15 21:45:12,708 - INFO - [cached since 73.58s ago] (8,)
+2025-11-15 21:45:12,748 - INFO - 
+            SELECT b.book_id, b.title, a.name AS author_name, b.year_published, b.isbn, b.cover_img_url, cb.position
+            FROM collection_books cb
+            JOIN books b ON cb.book_id = b.book_id
+            LEFT JOIN authors a ON b.author_id = a.author_id
+            WHERE cb.collection_id = $1
+            ORDER BY cb.position NULLS LAST, b.title
+        
+2025-11-15 21:45:12,748 - INFO - [cached since 73.54s ago] (8,)
+2025-11-15 21:45:12,770 - INFO - ROLLBACK

--- a/backend/src/app/schemas/requests.py
+++ b/backend/src/app/schemas/requests.py
@@ -16,4 +16,4 @@ class SearchBookRequest(BaseModel):
 
 class CreateCollectionRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
-    iconId: int = Field(..., ge=1, le=12) # 12 is the upper bound for now. Cannot go above 12 icon ids
+    iconId: int = Field(..., ge=1, le=21)  #Fixed to match the 21 icon options we now have

--- a/frontend/js/profile.js
+++ b/frontend/js/profile.js
@@ -571,10 +571,22 @@ document.addEventListener('DOMContentLoaded', () => {
       data = await res.json();
 
       if (!res.ok || (data && data.success == false)){
-        const msg=data?.error || `Request failed ({$res.status})`;
-        alert(`Couldnt create collection: ${msg}`);
+        let msg = data?.error || 'Something went wrong. Please try again.';
+
+        //context for common errors
+        if (res.status === 422) {
+          msg = data?.error || 'Invalid collection data.';
+        } else if (res.status === 401) {
+          msg = 'You need to be logged in to create collections.';
+        } else if (res.status === 500) {
+          msg = 'Server error. Please try again later.';
+        }
+
+        alert(`Couldn't create collection: ${msg}`);
+        console.error('Collection creation failed:', { status: res.status, data });
         return;
       }
+      
       form.reset();
       const popup = document.getElementById('popup');
       const backdrop = document.getElementById('popupBackdrop');


### PR DESCRIPTION
The schema file requests.py hadn't been updated since the additional collection icon SVGs were added. Collections could still only be made with the first 12 options and would error out if something else was chosen. This has been fixed. I also added better error messages for collection creation because that just seemed like a good idea.